### PR TITLE
Added optional parameter to pass the uuid used for the sentry event-id

### DIFF
--- a/src/raven_clj/core.clj
+++ b/src/raven_clj/core.clj
@@ -10,8 +10,8 @@
   "The name of this sentry client implementation"
   "raven-clj/1.4.2")
 
-(defn- generate-uuid []
-  (string/replace (UUID/randomUUID) #"-" ""))
+(defn- generate-uuid [& [uuid]]
+  (string/replace (or uuid (UUID/randomUUID)) #"-" ""))
 
 (defn make-sentry-url [uri project-id]
   (format "%s/api/%s/store/"
@@ -43,7 +43,7 @@
                     "/" (butlast (string/split url #"/"))))
      :project-id (Integer/parseInt (last (string/split url #"/")))}))
 
-(defn capture [dsn event-info]
+(defn capture [dsn event-info & {:keys [uuid]}]
   "Send a message to a Sentry server.
   event-info is a map that should contain a :message key and optional
   keys found at https://docs.getsentry.com/hosted/clientdev/#building-the-json-packet"
@@ -54,4 +54,4 @@
            :server_name (.getHostName (InetAddress/getLocalHost))
            :ts (str (Timestamp. (.getTime (Date.))))}
           event-info
-          {:event_id (generate-uuid)})))
+          {:event_id (generate-uuid uuid)})))

--- a/test/raven_clj/core_test.clj
+++ b/test/raven_clj/core_test.clj
@@ -3,7 +3,7 @@
   (:use clojure.test
         raven-clj.core)
   (:import [java.sql Timestamp]
-           [java.util Date]))
+           [java.util Date UUID]))
 
 (def example-dsn
   (str "https://"
@@ -89,4 +89,12 @@
         (with-redefs [send-packet (fn [ev] (reset! event-info ev))]
           (capture example-dsn {})
           (is (= (:platform @event-info) "clojure")
-              "should set :platform in event-info to clojure"))))))
+              "should set :platform in event-info to clojure"))))
+    (testing "with an explicit uuid"
+      (let [event-info (atom nil)
+            uuid (UUID/randomUUID)
+            event-id (#'raven-clj.core/generate-uuid uuid)]
+        (with-redefs [send-packet (fn [ev] (reset! event-info ev))]
+          (capture example-dsn {} :uuid uuid)
+          (is (= (:event_id @event-info) event-id)
+              (str "should set :event_id to " event-id)))))))


### PR DESCRIPTION
- Modified `capture` and `generate-uuid` to accept an explicit uuid to use
- Added unit-test
